### PR TITLE
Add query support through query strings

### DIFF
--- a/.github/workflows/evaluate-pr.yml
+++ b/.github/workflows/evaluate-pr.yml
@@ -1,0 +1,27 @@
+name: Build and publish
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '*.sln'
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dotnet-format and dotnet-sonarscanner
+        run: |
+          dotnet tool install --global dotnet-format
+          dotnet tool install --global dotnet-sonarscanner
+      - name: Check if the project is well formatted
+        run: |
+          ./scripts/start-lint.sh
+      - name: Build the project and run all tests     
+        run: |
+          ./scripts/start-tests.sh

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This project is an attempt to mimic [LimitOffsetPagination](https://www.django-r
 
     dotnet add package DrfLikePaginations
 
+It supports **queries in your data** given what is informed through the URL as query strings. You can get some details about how it works if you look at the tests in [PaginationITests.Queries](./tests/DrfLikePaginations/PaginationITests.cs) class.
+
 ## Sample output
 
 You can check out one sample output below from the project [ef-core-how-to-handle-migrations-in-production](https://github.com/willianantunes/tutorials/tree/d19609a50605a8d519ade3a568995da66568b212/2021/XX/ef-core-how-to-handle-migrations-in-production):
@@ -96,7 +98,7 @@ namespace EFCoreHandlingMigrations.Controllers.V1
         [HttpGet]
         public async Task<Paginated<TodoItem>> GetTodoItems()
         {
-            var query = _databaseSet.AsQueryable();
+            var query = _databaseSet.AsNoTracking().AsQueryable();
             var displayUrl = Request.GetDisplayUrl();
             var queryParams = Request.Query;
 

--- a/src/DrfLikePaginations.csproj
+++ b/src/DrfLikePaginations.csproj
@@ -7,7 +7,7 @@
     <PackageId>DrfLikePaginations</PackageId>
     <Version>0.1.0</Version>
     <Authors>Willian Antunes</Authors>
-    <Description>Tired of creating pagination all the time in your .NET project? Use this DRF like pagination and focus on business logic 🙂</Description>
+    <Description>Tired of creating pagination all the time in your .NET projects? Use this DRF like pagination and focus on business logic 🙂</Description>
     <PackageLicenseUrl>https://github.com/willianantunes/drf-like-paginations/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/willianantunes/drf-like-paginations</RepositoryUrl>
     <PackageTags>pagination;navigation;django</PackageTags>

--- a/src/DrfLikePaginations.csproj
+++ b/src/DrfLikePaginations.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>DrfLikePaginations</RootNamespace>
     <PackageId>DrfLikePaginations</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>Willian Antunes</Authors>
     <Description>Tired of creating pagination all the time in your .NET projects? Use this DRF like pagination and focus on business logic 🙂</Description>
     <PackageLicenseUrl>https://github.com/willianantunes/drf-like-paginations/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/Pagination.cs
+++ b/src/Pagination.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Web;
 using Microsoft.AspNetCore.Http;
@@ -26,6 +29,8 @@ namespace DrfLikePaginations
             // Extracting query strings
             var limitQueryParam = queryParams.FirstOrDefault(pair => pair.Key == _limitQueryParam);
             var offsetQueryParam = queryParams.FirstOrDefault(pair => pair.Key == _offsetQueryParam);
+            var allOthersParams =
+                queryParams.Where(pair => pair.Key != _limitQueryParam || pair.Key != _offsetQueryParam);
             // Setting basic data
             var numberOfRowsToSkip = RetrieveConfiguredOffset(offsetQueryParam.Value);
             var numberOfRowsToTake = RetrieveConfiguredLimit(limitQueryParam.Value);
@@ -33,7 +38,8 @@ namespace DrfLikePaginations
             var nextLink = RetrieveNextLink(url, numberOfRowsToSkip, numberOfRowsToTake, count);
             var previousLink = RetrievePreviousLink(url, numberOfRowsToSkip, numberOfRowsToTake);
             // Building list
-            var items = await source.Skip(numberOfRowsToSkip).Take(numberOfRowsToTake).ToListAsync();
+            IQueryable<T> filteredSource = FilterIfApplicable(source, allOthersParams);
+            var items = await filteredSource.Skip(numberOfRowsToSkip).Take(numberOfRowsToTake).ToListAsync();
 
             return new Paginated<T>(count, nextLink, previousLink, items);
         }
@@ -112,6 +118,75 @@ namespace DrfLikePaginations
             }
 
             return _defaultLimit;
+        }
+
+        private IQueryable<T> FilterIfApplicable<T>(IQueryable<T> source, IEnumerable<KeyValuePair<string, StringValues>> queryParams)
+        {
+            var propertiesToBeUsed = new Dictionary<PropertyInfo, string>();
+            var typeOfTheGivenGeneric = typeof(T);
+            var flags = BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance;
+
+            // Get all valid properties that were provided
+            foreach (var queryParam in queryParams)
+            {
+                var propertyName = queryParam.Key;
+                var propertyValue = queryParam.Value.ToString();
+                var property = typeOfTheGivenGeneric.GetProperty(propertyName, flags);
+                if (property is not null && propertyValue is not null)
+                    propertiesToBeUsed.Add(property, queryParam.Value.ToString());
+            }
+
+            var shouldApplyFiltering = propertiesToBeUsed.Count > 0;
+
+            if (shouldApplyFiltering)
+            {
+                var parameterExpression = Expression.Parameter(typeOfTheGivenGeneric);
+                var allPredicates = new List<Expression<Func<T, bool>>>();
+
+                // Create all predicates
+                foreach (var keyValuePair in propertiesToBeUsed)
+                {
+                    // Extract details
+                    var propertyInfo = keyValuePair.Key;
+                    var propertyType = propertyInfo.PropertyType;
+                    var value = keyValuePair.Value;
+                    // Create the expression
+                    var propertyOrFieldTarget = Expression.PropertyOrField(parameterExpression, propertyInfo.Name);
+                    try
+                    {
+                        var castedValue = Convert.ChangeType(value, propertyType);
+                        var valueToBeEqual = Expression.Constant(castedValue, propertyType);
+                        var finalExpression = Expression.Equal(propertyOrFieldTarget, valueToBeEqual);
+                        var predicate = Expression.Lambda<Func<T, bool>>(finalExpression, parameterExpression);
+                        // Add to list of predicates
+                        allPredicates.Add(predicate);
+                    }
+                    catch (FormatException)
+                    {
+                        // It happens let's say when you try to convert ABC to int, than raising FormatException 😉
+                    }
+                }
+
+                var hasPredicates = allPredicates.Count > 0;
+                if (hasPredicates)
+                {
+                    // Merge all predicates created
+                    Expression<Func<T, bool>> mergedPredicate = allPredicates.First();
+                    foreach (var (predicate, index) in allPredicates.Select((item, index) => (item, index)))
+                    {
+                        if (index is not 0)
+                        {
+                            InvocationExpression invocationExpression = Expression.Invoke(predicate, mergedPredicate.Parameters);
+                            mergedPredicate = Expression.Lambda<Func<T, bool>>(Expression.AndAlso(mergedPredicate.Body, invocationExpression), predicate.Parameters);
+                        }
+
+                    }
+
+                    return source.Where(mergedPredicate);
+                }
+            }
+
+            return source;
         }
     }
 }


### PR DESCRIPTION
It works exactly as [DRF DjangoFilterBackend](https://www.django-rest-framework.org/api-guide/filtering/#djangofilterbackend), though you can't specify which fields are allowed to be filtered. This implementation considers all the available properties.